### PR TITLE
Add `subdir` arg to `make_fix_file`

### DIFF
--- a/R/criterion.R
+++ b/R/criterion.R
@@ -70,7 +70,9 @@ root_criterion <- function(testfun, desc, subdir = NULL) {
   #'   }
   #' }
   criterion$make_fix_file <-
-    function(path = getwd()) make_fix_root_file(criterion, path)
+    function(path = getwd(), subdir = NULL) {
+      make_fix_root_file(criterion, path, subdir)
+    }
 
   criterion
 }

--- a/R/rrmake.R
+++ b/R/rrmake.R
@@ -5,7 +5,7 @@ make_find_root_file <- function(criterion) {
   }))
 }
 
-make_fix_root_file <- function(criterion, path, subdir) {
+make_fix_root_file <- function(criterion, path, subdir=NULL) {
   root <- find_root(criterion = criterion, path = path)
   if (!is.null(subdir)) {root <- file.path(root, subdir)}
   eval(bquote(function(...) {

--- a/R/rrmake.R
+++ b/R/rrmake.R
@@ -5,8 +5,9 @@ make_find_root_file <- function(criterion) {
   }))
 }
 
-make_fix_root_file <- function(criterion, path) {
+make_fix_root_file <- function(criterion, path, subdir) {
   root <- find_root(criterion = criterion, path = path)
+  if (!is.null(subdir)) {root <- file.path(root, subdir)}
   eval(bquote(function(...) {
     file.path(.(root), ...)
   }))


### PR DESCRIPTION
Fixes #32 

## How it works

```
    > myTestHelperFun <- is_testthat$make_fix_file()
    > myTestHelperFun("foo.txt")
    [1] ".../rprojroot/tests/testthat/foo.txt"
    > myTestHelperFunTwo <- is_testthat$make_fix_file(subdir = "woot")
    > myTestHelperFunTwo("bar.txt")
    [1] ".../rprojroot/tests/testthat/woot/bar.txt"
```

## Fails tests

> 1. Error: Shortcuts (@test-make.R#7) -------------------------------------------
argument "subdir" is missing, with no default

So, either:

1. change the test
2. make `subdir=NULL` the default for `make_fix_root_file()`

## What next

I'm not sure whether to change the default behavior or not, so I'll wait for response from @krlmlr