### PR TITLE
Alternate version control system project names

### DIFF
--- a/R/has-file.R
+++ b/R/has-file.R
@@ -191,21 +191,21 @@ str.root_criteria <- function(object, ...) {
 "is_projectile_project"
 
 #' @details
-#' `is_git_project` looks for a `.git` directory.
+#' `is_git_root` looks for a `.git` directory.
 #'
 #' @rdname criteria
 #' @export
 "is_git_root"
 
 #' @details
-#' `is_svn_project` looks for a `.svn` directory.
+#' `is_svn_root` looks for a `.svn` directory.
 #'
 #' @rdname criteria
 #' @export
 "is_svn_root"
 
 #' @details
-#' `is_vcs_project` looks for the root of a version control
+#' `is_vcs_root` looks for the root of a version control
 #' system, currently only Git and SVN are supported.
 #'
 #' @rdname criteria

--- a/docs/reference/criteria.html
+++ b/docs/reference/criteria.html
@@ -117,9 +117,9 @@
     <code>is_r_package</code> looks for a <code>DESCRIPTION</code> file.
     <code>is_remake_project</code> looks for a <code>remake.yml</code> file.
     <code>is_projectile_project</code> looks for a <code>.projectile</code> file.
-    <code>is_git_project</code> looks for a <code>.git</code> directory.
-    <code>is_svn_project</code> looks for a <code>.svn</code> directory.
-    <code>is_vcs_project</code> looks for the root of a version control
+    <code>is_git_root</code> looks for a <code>.git</code> directory.
+    <code>is_svn_root</code> looks for a <code>.svn</code> directory.
+    <code>is_vcs_root</code> looks for the root of a version control
 system, currently only Git and SVN are supported.
     <code>is_testthat</code> looks for the <code>testthat</code> directory, works when
 developing, testing, and checking a package.

--- a/man/criteria.Rd
+++ b/man/criteria.Rd
@@ -47,11 +47,11 @@ This is a collection of commonly used root criteria.
 
 \code{is_projectile_project} looks for a \code{.projectile} file.
 
-\code{is_git_project} looks for a \code{.git} directory.
+\code{is_git_root} looks for a \code{.git} directory.
 
-\code{is_svn_project} looks for a \code{.svn} directory.
+\code{is_svn_root} looks for a \code{.svn} directory.
 
-\code{is_vcs_project} looks for the root of a version control
+\code{is_vcs_root} looks for the root of a version control
 system, currently only Git and SVN are supported.
 
 \code{is_testthat} looks for the \code{testthat} directory, works when


### PR DESCRIPTION
I just found stale documents.

These root directories on version control systems, so `is_git_project()`, `is_svn_project()` and `is_vcs_project()` now using `*_root()`. since [v1.2](https://github.com/krlmlr/rprojroot/commit/6d1069cd9fa2eed22364707c5e7be194d3e4ecdc) 

Rscript, Rdocuments and pkgdown page updated.
